### PR TITLE
feature: #6 동적 크롤링으로 상세페이지 주소 접근

### DIFF
--- a/src/main/java/org/example/scraper/DynamicJobScraperVer2.java
+++ b/src/main/java/org/example/scraper/DynamicJobScraperVer2.java
@@ -1,0 +1,126 @@
+package org.example.scraper;
+
+import org.example.recruitment.RecruitmentNotice;
+import org.example.setting.DynamicSiteSetting;
+import org.example.setting.DynamicSiteSettingCollection;
+import org.example.setting.DynamicSiteSettingCollectionVer2;
+import org.openqa.selenium.*;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public class DynamicJobScraperVer2 extends JobScraper<DynamicSiteSettingCollectionVer2> {
+	private final WebDriver webDriver;
+
+	public DynamicJobScraperVer2(DynamicSiteSettingCollectionVer2 setting, WebDriver webDriver) {
+		super(setting);
+		this.webDriver = webDriver;
+	}
+
+	@Override
+	public List<RecruitmentNotice> scrapingBy(DynamicSiteSettingCollectionVer2 setting) {
+
+		List<RecruitmentNotice> allJobs = new ArrayList<>();
+
+		for (DynamicSiteSetting site : setting.getSites()) {
+			allJobs.addAll(scraping(site));
+		}
+		return allJobs;
+	}
+
+	private List<RecruitmentNotice> scraping(DynamicSiteSetting setting) {
+		List<RecruitmentNotice> jobs = new ArrayList<>();
+		try {
+			webDriver.get(setting.getUrl());
+			JavascriptExecutor js = (JavascriptExecutor) webDriver;
+
+			WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(10));
+			List<WebElement> elements = webDriver.findElements(By.xpath("//*[@id=\"naver\"]/div/section/div/div/div[2]/div[2]/ul/li[*]/a"));
+			Actions actions = new Actions(webDriver);
+
+			// * 메서드 뺄것
+			while (true){
+				actions.sendKeys(org.openqa.selenium.Keys.PAGE_DOWN).perform();  // 한 페이지 아래로 이동
+				List<WebElement> elements2 = webDriver.findElements(By.xpath("//*[@id=\"naver\"]/div/section/div/div/div[2]/div[2]/ul/li[*]/a"));
+				if (elements.size() == elements2.size()) {
+					break;
+				}
+			}
+			//
+
+
+			for (int i = 0; i < elements.size(); i++) {
+
+				while (true){
+					actions.sendKeys(org.openqa.selenium.Keys.PAGE_DOWN).perform();  // 한 페이지 아래로 이동
+					List<WebElement> elements2 = webDriver.findElements(By.xpath("//*[@id=\"naver\"]/div/section/div/div/div[2]/div[2]/ul/li[*]/a"));
+					if (elements.size() == elements2.size()) {
+						break;
+					}
+				}
+//				Thread.sleep(1000);
+
+				WebElement element = wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("//*[@id=\"naver\"]/div/section/div/div/div[2]/div[2]/ul/li[" + (i+1) + "]/a")));
+				js.executeScript("arguments[0].scrollIntoView(true);", element);
+				js.executeScript("arguments[0].click();", element);
+				webDriver.get(setting.getUrl());
+//				actions.moveToElement(element).click().perform();
+				// 요소가 클릭 가능할 때까지 대기
+//				element = wait.until(ExpectedConditions.elementToBeClickable(element));
+
+//				// 클릭
+//				element.click();
+
+				break;
+//
+			}
+
+//			WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(10));
+//			WebElement jobList = wait.until(
+//				ExpectedConditions.presenceOfElementLocated(By.xpath(setting.getJobListSelector())));
+//
+//			List<WebElement> jobElements = jobList.findElements(By.xpath(setting.getJobDetailSelector()));
+//
+//			if (jobElements.isEmpty()) {
+//				System.out.println("❌ 공고 리스트가 비어 있음. XPath 확인 필요: " + setting.getJobListSelector());
+//			}
+//
+//			for (WebElement jobElement : jobElements) {
+//				try {
+//					WebElement linkElement = null;
+//					String title = null;
+//					String link = null;
+//
+//					// ✅ href를 포함한 a 태그 찾기
+//					try {
+//						if (jobElement.getTagName().equals("a")) {
+//							linkElement = jobElement;
+//						} else {
+//							linkElement = jobElement.findElement(By.tagName("a"));
+//						}
+//						link = linkElement.getAttribute("href");
+//					} catch (NoSuchElementException e) {
+//						System.out.println("⚠️ a 태그 없음");
+//					}
+//
+//					title = jobElement.getAttribute("innerText");
+//					if (title != null && link != null) {
+//						jobs.add(RecruitmentNotice.create(setting.getSiteName(), title, link));
+//					}
+//				} catch (Exception e) {
+//					System.out.println("⚠️ 특정 jobElement에서 데이터를 가져올 수 없음: " + e.getMessage());
+//				}
+//			}
+		} catch (Exception e) {
+			System.out.println("❌ 오류 발생: " + e.getMessage());
+			e.printStackTrace();
+		}
+		return jobs;
+	}
+
+}

--- a/src/main/java/org/example/setting/DynamicSiteSettingCollectionVer2.java
+++ b/src/main/java/org/example/setting/DynamicSiteSettingCollectionVer2.java
@@ -1,0 +1,20 @@
+package org.example.setting;
+
+import lombok.Getter;
+import org.example.mapper.DataMapper;
+
+import java.io.IOException;
+import java.util.List;
+
+@Getter
+public class DynamicSiteSettingCollectionVer2 implements SettingCollection<DynamicSiteSettingCollectionVer2> {
+	private List<DynamicSiteSetting> sites;
+
+	@Override
+	public DynamicSiteSettingCollectionVer2 init(DataMapper mapper) throws IOException {
+		DynamicSiteSettingCollectionVer2 loaded = mapper.readFromJson(DynamicSiteSettingCollectionVer2.class,
+			"dynamic_site_config_test.json");
+		this.sites = loaded.getSites();
+		return this;
+	}
+}

--- a/src/main/resources/dynamic_site_config_test.json
+++ b/src/main/resources/dynamic_site_config_test.json
@@ -1,0 +1,10 @@
+{
+  "sites": [
+    {
+      "siteName": "네이버",
+      "url": "https://recruit.navercorp.com/rcrt/list.do?srchClassCd=1000000",
+      "jobListSelector": "//*[@id='0d34fec3-9738-4eb7-9fe7-f720bb99ec73']/div/div/div[2]/div[2]/ul",
+      "jobDetailSelector": "./a"
+    }
+  ]
+}


### PR DESCRIPTION
일단 클래스 이름은 DynamicSite~~Ver2 이렇게 해놨고, 
1. 항목을 클릭
2. url을 가져오고 json에 저장
3. 이전 페이지로 이동.
4. 마지막 항목이고 다음 페이지가 있다면 다음 페이지로 이동.(페이지 네이션의 경우)
5. 마지막 항목이고 다음 페이지가 없다면 다음 사이트로 이동.(페이지 네이션의 경우)

이렇게 수도코드가 될 듯 합니다.

XPath를 입력해서 클릭이 필요한 경우도 두가지 케이스로 나눠야 할 껀데,
1. 페이지 네이션이 없는 페이지 (아마 무한 스크롤 방식일듯 합니다. 해당 케이스는 스크롤을 내리는 기능이 필요.
7. 페이지 네이션이 있다면, 다음 페이지를 호출 할 수 있는 태그의 xpath 
이렇게 구현해야 할 것 같습니다.
